### PR TITLE
Fix crash in analytics on the tick endpoint

### DIFF
--- a/Minion/class.minion.plugin.php
+++ b/Minion/class.minion.plugin.php
@@ -2458,7 +2458,7 @@ EOT;
     public function gdn_statistics_analyticsTick_handler($sender) {
         $controller = Gdn::controller();
         if ($controller) {
-            $this->minionUpkeep();
+            $this->minionUpkeep($controller);
         }
     }
 

--- a/Minion/class.minion.plugin.php
+++ b/Minion/class.minion.plugin.php
@@ -2456,7 +2456,10 @@ EOT;
      * @param Gdn_Statistics $sender
      */
     public function gdn_statistics_analyticsTick_handler($sender) {
-        $this->minionUpkeep(Gdn::controller());
+        $controller = Gdn::controller();
+        if ($controller) {
+            $this->minionUpkeep();
+        }
     }
 
     /**


### PR DESCRIPTION
The tick endpoint fires an analytics tick but doesn't have any `Gdn_Controller` instance, such as when called on the `/api/v2/tick` endpoint.

In fairness I have no idea what this whole setup does, but I'm trying to clear it out of our errors.