### PR TITLE
VANS-119: Fix badly formed conditional check

### DIFF
--- a/Minion/class.minion.plugin.php
+++ b/Minion/class.minion.plugin.php
@@ -495,7 +495,7 @@ class MinionPlugin extends Gdn_Plugin {
         $type = val('Type', $sender->EventArguments, 'rules');
 
         // Nothing happening?
-        if (!($kickedUsers | $bannedPhrases | $force)) {
+        if (empty($kickedUsers) && empty($bannedPhrases) && empty($force)) {
             return;
         }
 


### PR DESCRIPTION
A strange conditional check was breaking access all discussions where a user had been kicked. This fixes the problem.

Issue here: https://higherlogic.atlassian.net/browse/VANS-119